### PR TITLE
Update craftos.d.ts. Fixes #5

### DIFF
--- a/types/craftos/craftos.d.ts
+++ b/types/craftos/craftos.d.ts
@@ -775,8 +775,9 @@ declare class Vector {
     public tostring(this: Vector): string;
     public equals(this: Vector, o: Vector): boolean;
 }
-/** @customConstructor window.create */
-/** @noSelf */
+/**
+ * @customConstructor window.create
+ * @noSelf */
 declare class Window implements ITerminal {
     constructor(parent: ITerminal, x: number, y: number, width: number, height: number, visible?: boolean);
     public write(text: string): void;


### PR DESCRIPTION
In order to use multiple annotations with TypeScriptToLua you must use JSDoc annotation style, which dictates that multiple annotations be stored in one multiline comment.
#5