### PR TITLE
Events not properly initializing

### DIFF
--- a/event.ts
+++ b/event.ts
@@ -352,7 +352,7 @@ type Constructor<T extends {} = {}> = new (...args: any[]) => T;
 export function pullEventRaw(filter: string | null = null): IEvent | null {
     let args: any[] = table.pack(coroutine.yield(filter));
     for (let init of eventInitializers) {
-        let ev = init(args);
+        let ev = init(args[0]);
         if (ev != null) return ev;
     }
     return GenericEvent.init(args);

--- a/event.ts
+++ b/event.ts
@@ -350,9 +350,9 @@ let eventInitializers: ((args: any[]) => IEvent | null)[] = [
 
 type Constructor<T extends {} = {}> = new (...args: any[]) => T;
 export function pullEventRaw(filter: string | null = null): IEvent | null {
-    let args: any[] = table.pack(coroutine.yield(filter));
+    let args = table.pack(...coroutine.yield(filter));
     for (let init of eventInitializers) {
-        let ev = init(args[0]);
+        let ev = init(args);
         if (ev != null) return ev;
     }
     return GenericEvent.init(args);


### PR DESCRIPTION
Hello !

First, thank you for your work it's making my DX a lot better :)

While playing around I found an issue with the events initialization. In the `event.ts` file, you are sending the arguments to the initializers, but it seems that the object to check is wrapped by `table.pack`. This causes all events to fallback to the generic event (I've noticed this behavior on the KeyEvent).

I'm running "ComputerCraft: Tweaked" on version 1.111.0, I guess there has been an update that changes it ?