### PR TITLE
add explicit typings, add file-based package resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,32 +1,28 @@
 {
   "name": "cc-tstl-template",
-  "version": "1.109.3",
+  "version": "1.113.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cc-tstl-template",
-      "version": "1.109.3",
+      "version": "1.113.1",
       "license": "MIT",
       "devDependencies": {
-        "@jackmacwindows/cc-types": "^1.0.0",
-        "@jackmacwindows/craftos-types": "^1.1.1",
+        "@jackmacwindows/cc-types": "file:types/cc",
+        "@jackmacwindows/craftos-types": "file:types/craftos",
         "@jackmacwindows/lua-types": "^2.13.2",
         "@jackmacwindows/typescript-to-lua": "^1.22.0",
         "typescript": "^5.1.0"
       }
     },
     "node_modules/@jackmacwindows/cc-types": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@jackmacwindows/cc-types/-/cc-types-1.0.1.tgz",
-      "integrity": "sha512-Bs67MsLWgCfO4CsaOaxsRcwiOsSOb0lfB0dxNgg7os8ST/5hiccZxuXw0JxImL1RGT66mmAA1qvcsJYUGIXjRA==",
-      "dev": true
+      "resolved": "types/cc",
+      "link": true
     },
     "node_modules/@jackmacwindows/craftos-types": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@jackmacwindows/craftos-types/-/craftos-types-1.1.3.tgz",
-      "integrity": "sha512-cgdUWvMsl8JOK7EQzNoP6S2P+B+WuTXdLDDxvwfEBnrMSzxWITCdTF8EEzgeiUaAflbnIAoLJJ1XxI33h4+iFA==",
-      "dev": true
+      "resolved": "types/craftos",
+      "link": true
     },
     "node_modules/@jackmacwindows/lua-types": {
       "version": "2.13.2",
@@ -191,6 +187,18 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "types/cc": {
+      "name": "@jackmacwindows/cc-types",
+      "version": "1.0.1",
+      "dev": true,
+      "license": "MIT"
+    },
+    "types/craftos": {
+      "name": "@jackmacwindows/craftos-types",
+      "version": "1.1.3",
+      "dev": true,
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "typescript": "^5.1.0",
     "@jackmacwindows/lua-types": "^2.13.2",
     "@jackmacwindows/typescript-to-lua": "^1.22.0",
-    "@jackmacwindows/craftos-types": "^1.1.1",
-    "@jackmacwindows/cc-types": "^1.0.0"
+    "@jackmacwindows/craftos-types": "file:types/craftos",
+    "@jackmacwindows/cc-types": "file:types/cc"
   },
   "author": "JackMacWindows",
   "license": "MIT"

--- a/types/craftos/craftos.d.ts
+++ b/types/craftos/craftos.d.ts
@@ -509,10 +509,13 @@ declare class FluidStoragePeripheral implements IPeripheral {
     pullFluid(from: string, limit?: number, name?: string): number;
 }
 
-declare type ItemDetail = {
+declare type SlotDetail = {
     name: string;
-    count: string;
+    count: number;
     nbt?: string;
+}
+
+declare type ItemDetail = SlotDetail & {
     displayName: string;
     maxCount: number;
     damage?: number;
@@ -527,7 +530,7 @@ declare type ItemDetail = {
 /** @noSelf */
 declare class InventoryPeripheral implements IPeripheral {
     size(): number;
-    list(): {[index: number]: {name: string, count: number, nbt?: string}};
+    list(): {[index: number]: SlotDetail};
     getItemDetail(slot: number): ItemDetail|undefined;
     getItemLimit(slot: number): number;
     pushItems(to: string, slot: number, limit?: number, toSlot?: number): number;


### PR DESCRIPTION
This pull request contains two simple changes, one adds an explicit typing and one small fix to the type of the CraftOS declaration, and the other changes the package resolution to local files.

You can see my reasoning for both of these changes on the individual commits.