### PR TITLE
Add getTextScale method to craftos.d.ts

### DIFF
--- a/types/craftos/craftos.d.ts
+++ b/types/craftos/craftos.d.ts
@@ -472,6 +472,7 @@ declare class MonitorPeripheral implements IPeripheral, ITerminal {
     setPixels(x: number, y: number, data: Color | (string | Color[])[]): void;
     getFrozen(): boolean;
     setFrozen(frozen: boolean): void;
+    getTextScale(): number;
     setTextScale(scale: number): void;
 }
 


### PR DESCRIPTION
As mentioned in the title, this PR adds the getTextScale method to the MonitorPeripheral within craftos.d.ts
[offical doc](https://tweaked.cc/peripheral/monitor.html#v:getTextScale)